### PR TITLE
[SFE-2134] HealthKit active (exercise) minutes

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Activity.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Activity.h
@@ -15,5 +15,6 @@
 - (void)activity_getActiveEnergyDailySamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)activity_getBasalEnergyBurned:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)activity_getBasalEnergyDailySamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)activity_getAppleExerciseMinutes:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Activity.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Activity.m
@@ -135,4 +135,35 @@
                                      }];
 }
 
+- (void)activity_getAppleExerciseMinutes:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    HKQuantityType *exerciseType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierAppleExerciseTime];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit minuteUnit]];
+    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+
+    if(startDate == nil){
+        callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
+        return;
+    }
+
+    [self fetchCumulativeSumStatisticsCollection:exerciseType
+                                            unit:unit
+                                       startDate:startDate
+                                         endDate:endDate
+                                       ascending:ascending
+                                           limit:HKObjectQueryNoLimit
+                                      completion:^(NSArray *results, NSError *error) {
+                                          if(results){
+                                              callback(@[[NSNull null], results]);
+                                              return;
+                                          } else {
+                                              NSLog(@"error getting exercise time: %@", error);
+                                              callback(@[RCTMakeError(@"error  getting exercise time", nil, nil)]);
+                                              return;
+                                          }
+                                      }];
+}
+
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -57,10 +57,15 @@
     }else if ([@"NikeFuel" isEqualToString: key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierNikeFuel];
     }
-
-//    if ([@"AppleExerciseTime" isEqualToString: key]) {
-//        return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierAppleExerciseTime];
-//    }
+    else if ([@"AppleExerciseTime" isEqualToString: key] && systemVersion >= 9.3) {
+       return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierAppleExerciseTime];
+    }
+    else if ([@"AppleStandHours" isEqualToString: key] && systemVersion >= 9.0) {
+       return [HKObjectType categoryTypeForIdentifier:HKCategoryTypeIdentifierAppleStandHour];
+    }
+    else if ([@"ActivitySummary" isEqualToString: key] && systemVersion >= 9.3) {
+       return [HKObjectType activitySummaryType];
+    }
 
     // Nutrition Identifiers
     if ([@"DietaryEnergy" isEqualToString: key]) {

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -232,6 +232,11 @@ RCT_EXPORT_METHOD(getBasalEnergyDailySamples:(NSDictionary *)input callback:(RCT
    [self activity_getBasalEnergyDailySamples:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(getAppleExerciseMinutes:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+   [self activity_getAppleExerciseMinutes:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(getBodyTemperatureSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self vitals_getBodyTemperatureSamples:input callback:callback];


### PR DESCRIPTION
Added support for fetching active (exercise minutes).

> Added new permissions for AppleExerciseTime, AppleStandHours and ActivitySummary (not currently using stand hours and activity summary, but will soon).
> Added activity_getAppleExerciseMinutes to get exercise minutes 
> Added background syncing of exercise minutes (need a proper build to verify function).

Once these changes are merged, they will be tagged and package.json will need to be updated in Sprout30 PR https://github.com/sproutatwork/Sprout30/pull/2387