### PR TITLE
[SFE-2134] Background active minutes int

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sprout.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sprout.m
@@ -497,7 +497,7 @@
                                            } 
                                            [dayActivity setObject:sourceNames forKey:@"deviceName"];
                                            
-                                           double minutesValue = [quantity doubleValueForUnit:[HKUnit minuteUnit]];
+                                           int minutesValue = (int)[quantity doubleValueForUnit:[HKUnit minuteUnit]];
                                            
                                            NSDictionary *metrics = [NSDictionary dictionaryWithObject:[NSNumber numberWithInt:minutesValue] forKey:@"medIntensity"];
                                            [dayActivity setObject:metrics forKey:@"metrics"];


### PR DESCRIPTION
Making sure the active minutes value for background sync is an int