### PR TITLE
[SFE-3276] Fixed crash getting device info for background workout sync

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sprout.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sprout.m
@@ -302,23 +302,28 @@
                     [activity setObject:endDateString forKey:@"endTime"];
                     [activity setObject:[self getTimeOffsetString] forKey:@"offset"];
 
-                    NSDictionary *deviceInfo = [self deviceInfoForSample:sample];
-					NSString *sourceName = [deviceInfo objectForKey:@"sourceName"];
-					NSString *productType = [deviceInfo objectForKey:@"productType"];  
+                    HKSourceRevision *sourceRevision = [sample objectForKey:@"sourceRevision"];
+                    if (sourceRevision) {
+                        NSString *sourceName = [[sourceRevision source] name];
+					    NSString *productType = [sourceRevision productType];  
 
-                    NSMutableString *deviceName = [[NSMutableString alloc] init];
-                    if (productType && sourceName) {
-                        [deviceName appendString:productType];
-                        [deviceName appendString:@" - "];
-                        [deviceName appendString:sourceName];
-                    } else if (productType) {
-                        deviceName = productType;
-                    } else if (sourceName) {
-                        deviceName = sourceName;
+                        NSMutableString *deviceName = [[NSMutableString alloc] init];
+                        if (productType && sourceName) {
+                            [deviceName appendString:productType];
+                            [deviceName appendString:@" - "];
+                            [deviceName appendString:sourceName];
+                        } else if (productType) {
+                            deviceName = productType;
+                        } else if (sourceName) {
+                            deviceName = sourceName;
+                        } else {
+                            deviceName = @"Apple Health";
+                        }
+                        [activity setObject:deviceName forKey:@"deviceName"];
                     } else {
-                        deviceName = @"Apple Health";
+                        NSString *deviceName = @"Apple Health";
+                        [activity setObject:deviceName forKey:@"deviceName"];
                     }
-                    [activity setObject:deviceName forKey:@"deviceName"];
                     
                     NSDictionary *metrics = @{
                                              @"duration": @([[sample objectForKey:@"duration"] intValue]),

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sprout.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sprout.m
@@ -305,7 +305,7 @@
                     HKSourceRevision *sourceRevision = [sample objectForKey:@"sourceRevision"];
                     if (sourceRevision) {
                         NSString *sourceName = [[sourceRevision source] name];
-					    NSString *productType = [sourceRevision productType];  
+			NSString *productType = [sourceRevision productType];  
 
                         NSMutableString *deviceName = [[NSMutableString alloc] init];
                         if (productType && sourceName) {


### PR DESCRIPTION
The sample object in the workout background query was an NSDictionary, not and HKSample. Passing the sample in to deviceInfoForSample would cause a crash. 

Now getting the sourceRevision object from the sample dictionary to get the device info.