### PR TITLE
[SFE-3845] Crash in deviceInfoForSample

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -838,11 +838,11 @@
 - (NSDictionary *)deviceInfoForSample:(HKSample *)sample {
     if (sample && [sample isKindOfClass:[HKSample class]]) {
         NSString *deviceName = @"";
-        if ([sample device]) {
+        if ([[sample device] name]) {
             deviceName = [[sample device] name];
         }
         NSString *deviceModel = @"";
-        if ([sample device]) {
+        if ([[sample device] model]) {
             deviceModel = [[sample device] model];
         }
         NSString *sourceName = @"";


### PR DESCRIPTION
- Name or model properties on [sample device] could potentially be null.
- We were checking if [sample device] existed, but not name/model on device.
- Adding a null object to the dictionary would cause a crash.
- Fixed by checking if name and model exist, before setting deviceName and deviceModel to add to the dictionary